### PR TITLE
 bunch of fixes (can't think of a better title, feel free to edit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 This is the Linux / macOS / Unix client for Heartbeat. It will ping the central server every minute, as long as an input device (keyboard or mouse) has been used in the last two minutes, and your device is unlocked.
 
-Do note, that checking for a screen lock only works on KDE's `kscreenlocker`. If you are on a different DE / screenlocker, feel free to make a pull request adding support for that DE / screenlocker.
+Currently, Wayland support is not available, since the equivalent of `xprintidle` isn't available.
+
+You can configure a screen locker that the script will use to determine if your screen is locked (it
+just `pgrep`s it, so use the appropriate name).
 
 # Jump to
 - [Usage (for most \*NIX-like systems)](#usage-for-most-nix-like-systems)
@@ -27,6 +30,7 @@ export HEARTBEAT_AUTH='your heartbeat server token'
 export HEARTBEAT_HOSTNAME="https://your.heartbeat.domain"
 export HEARTBEAT_LOG_DIR="$HOME/.cache"
 export HEARTBEAT_DEVICE_NAME="Linux Device"
+export HEARTBEAT_SCREEN_LOCK="kscreenlocker"  # or whatever screen locker you use
 ```
 
 3. Download and install the systemd service

--- a/scripts/heartbeat-client-macOS.sh
+++ b/scripts/heartbeat-client-macOS.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 if ! [ -e "$HOME/.heartbeat" ]; then
     echo "$HOME/.heartbeat not setup, please create it"
@@ -8,7 +8,7 @@ fi
 # shellcheck disable=SC1091
 . "$HOME/.heartbeat"
 
-if [[ -z "$HEARTBEAT_AUTH" ]] || [[ -z "$HEARTBEAT_LOG_DIR" ]] || [[ -z "$HEARTBEAT_HOSTNAME" ]] || [[ -z "$HEARTBEAT_DEVICE_NAME" ]]; then
+if [ -z "$HEARTBEAT_AUTH" ] || [ -z "$HEARTBEAT_LOG_DIR" ] || [ -z "$HEARTBEAT_HOSTNAME" ] || [ -z "$HEARTBEAT_DEVICE_NAME" ]; then
     echo "Environment variables not setup correctly!"
     echo "HEARTBEAT_AUTH: $HEARTBEAT_AUTH"
     echo "HEARTBEAT_LOG_DIR: $HEARTBEAT_LOG_DIR"
@@ -17,7 +17,7 @@ if [[ -z "$HEARTBEAT_AUTH" ]] || [[ -z "$HEARTBEAT_LOG_DIR" ]] || [[ -z "$HEARTB
     exit 1
 else
     # Make log dir if it doesn't exist
-    if ! [[ -d "$HEARTBEAT_LOG_DIR" ]]; then
+    if ! [ -d "$HEARTBEAT_LOG_DIR" ]; then
         mkdir -p "$HEARTBEAT_LOG_DIR" || exit 1
     fi
 
@@ -25,7 +25,7 @@ else
     LAST_INPUT_SEC="$(($(ioreg -c IOHIDSystem | sed -e '/HIDIdleTime/ !{ d' -e 't' -e '}' -e 's/.* = //g' -e 'q') / 1000000000))"
 
     # Launchd will not execute the task if the system is locked or sleeping, so no need to worry about the screen lock state
-    if [[ $LAST_INPUT_SEC -lt 120 ]]; then
+    if [ $LAST_INPUT_SEC -lt 120 ]; then
         {
             echo "$(date +"%Y/%m/%d %T") - Running Heartbeat"
             curl -s -X POST -H "Auth: $HEARTBEAT_AUTH" -H "Device: $HEARTBEAT_DEVICE_NAME" "$HEARTBEAT_HOSTNAME/api/beat"

--- a/scripts/heartbeat-client-unix.sh
+++ b/scripts/heartbeat-client-unix.sh
@@ -20,6 +20,8 @@ else
     if [ ! -d "$HEARTBEAT_LOG_DIR" ]; then
         mkdir -p "$HEARTBEAT_LOG_DIR" || exit 1
     fi
++
+    if
     if [ -z "$(which xprintidle)" ]; then
         echo "xprintidle not found, please install it!"
         exit 1

--- a/scripts/heartbeat-client-unix.sh
+++ b/scripts/heartbeat-client-unix.sh
@@ -8,12 +8,13 @@ fi
 # shellcheck disable=SC1091
 . "$HOME/.env"
 
-if [ -z "$HEARTBEAT_AUTH" ] || [ -z "$HEARTBEAT_LOG_DIR" ] || [ -z "$HEARTBEAT_HOSTNAME" ] || [ -z "$HEARTBEAT_DEVICE_NAME" ]; then
+if [ -z "$HEARTBEAT_AUTH" ] || [ -z "$HEARTBEAT_LOG_DIR" ] || [ -z "$HEARTBEAT_HOSTNAME" ] || [ -z "$HEARTBEAT_DEVICE_NAME" ] || [ -z "$HEARTBEAT_SCREEN_LOCK" ]; then
     echo "Environment variables not setup correctly!"
     echo "HEARTBEAT_AUTH: $HEARTBEAT_AUTH"
     echo "HEARTBEAT_LOG_DIR: $HEARTBEAT_LOG_DIR"
     echo "HEARTBEAT_HOSTNAME: $HEARTBEAT_HOSTNAME"
     echo "HEARTBEAT_DEVICE_NAME: $HEARTBEAT_DEVICE_NAME"
+    echo "HEARTBEAT_SCREEN_LOCK: $HEARTBEAT_SCREEN_LOCK"
     exit 1
 else
     if [ -z "$(which xprintidle)" ]; then
@@ -22,7 +23,7 @@ else
     fi
 
     # Check if kscreenlocker is running. Only works on KDE
-    SCREEN_LOCKED="$(pgrep kscreenlocker)"
+    SCREEN_LOCKED="$(pgrep "$HEARTBEAT_SCREEN_LOCK")"
     # Check when the last keyboard or mouse event was sent
     LAST_INPUT_MS="$(xprintidle)"
 

--- a/scripts/heartbeat-client-unix.sh
+++ b/scripts/heartbeat-client-unix.sh
@@ -27,7 +27,7 @@ else
         exit 1
     fi
 
-    # Check if kscreenlocker is running. Only works on KDE
+    # Check if screenlocker program is running / locked (default `kscreenlocker`).
     SCREEN_LOCKED="$(pgrep "$HEARTBEAT_SCREEN_LOCK")"
     # Check when the last keyboard or mouse event was sent
     LAST_INPUT_MS="$(xprintidle)"

--- a/scripts/heartbeat-client-unix.sh
+++ b/scripts/heartbeat-client-unix.sh
@@ -17,6 +17,9 @@ if [ -z "$HEARTBEAT_AUTH" ] || [ -z "$HEARTBEAT_LOG_DIR" ] || [ -z "$HEARTBEAT_H
     echo "HEARTBEAT_SCREEN_LOCK: $HEARTBEAT_SCREEN_LOCK"
     exit 1
 else
+    if [ ! -d "$HEARTBEAT_LOG_DIR" ]; then
+        mkdir -p "$HEARTBEAT_LOG_DIR" || exit 1
+    fi
     if [ -z "$(which xprintidle)" ]; then
         echo "xprintidle not found, please install it!"
         exit 1


### PR DESCRIPTION
the plist invokes the script with `/bin/sh -c`, which (afaik) is a symlink to zsh on Macs produced in the last half a decade at least, so change the shebang and the `[[ ]]`s.

Also on an unrelated note, why the inconsistency in the env file naming (`~/.env` vs. `~/.heartbeat`)?

EDIT: I forgot I already opened a PR with this branch as the base, so the scope of this has increased a bit.

This PR now also allows for configuring the process name of the screen locker which is the simplest way of supporting various configurations of this. The docs also note the lack of Wayland support.

It also ensures that the log directory is created before writing to a file inside it.