### PR TITLE
fix: syntax error in `heartbeat-client-unix.sh`

### DIFF
--- a/scripts/heartbeat-client-unix.sh
+++ b/scripts/heartbeat-client-unix.sh
@@ -20,8 +20,7 @@ else
     if [ ! -d "$HEARTBEAT_LOG_DIR" ]; then
         mkdir -p "$HEARTBEAT_LOG_DIR" || exit 1
     fi
-+
-    if
+
     if [ -z "$(which xprintidle)" ]; then
         echo "xprintidle not found, please install it!"
         exit 1


### PR DESCRIPTION
see title;
removed 2 lines that was breaking the script